### PR TITLE
Rename `xor_cipher::in_place` functions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xor-cipher"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["nekitdev <nekit@nekit.dev>"]
 edition = "2021"
 description = "Simple, reusable and optimized XOR ciphers in Rust."
@@ -10,3 +10,6 @@ homepage = "https://xor-cipher.org/"
 repository = "https://github.com/xor-cipher/xor-cipher"
 license = "MIT"
 keywords = ["xor", "cipher"]
+
+[features]
+std = []

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or by directly specifying it in the configuration like so:
 
 ```toml
 [dependencies]
-xor-cipher = "1.1.0"
+xor-cipher = "2.0.0"
 ```
 
 Alternatively, you can add it directly from the source:

--- a/changelogging.toml
+++ b/changelogging.toml
@@ -1,6 +1,6 @@
 [context]
 name = "xor-cipher"
-version = "1.1.0"
+version = "2.0.0"
 url = "https://github.com/xor-cipher/xor-cipher-crate"
 
 [formats]

--- a/changes/1.change.md
+++ b/changes/1.change.md
@@ -1,0 +1,4 @@
+The following functions in `xor_cipher::in_place` were renamed:
+
+- `xor_in_place -> xor`;
+- `cyclic_xor_in_place -> cyclic_xor`.

--- a/src/in_place.rs
+++ b/src/in_place.rs
@@ -4,7 +4,7 @@
 ///
 /// This function is its own inverse.
 #[inline]
-pub fn xor_in_place(data: &mut [u8], key: u8) {
+pub fn xor(data: &mut [u8], key: u8) {
     data.iter_mut().for_each(|byte| *byte ^= key);
 }
 
@@ -13,7 +13,7 @@ pub fn xor_in_place(data: &mut [u8], key: u8) {
 ///
 /// This function is its own inverse.
 #[inline]
-pub fn cyclic_xor_in_place(data: &mut [u8], key: &[u8]) {
+pub fn cyclic_xor(data: &mut [u8], key: &[u8]) {
     data.iter_mut()
         .zip(key.iter().cycle())
         .for_each(|(byte, key_byte)| *byte ^= key_byte);


### PR DESCRIPTION
This PR renames the following functions in `xor_cipher::in_place`:

- `xor_in_place -> xor`;
- `cyclic_xor_in_place -> cyclic_xor`.