### PR TITLE
Use the inner function pattern.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xor-cipher"
-version = "3.0.0"
+version = "4.0.0"
 authors = ["nekitdev <nekit@nekit.dev>"]
 edition = "2021"
 description = "Simple, reusable and optimized XOR ciphers in Rust."

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or by directly specifying it in the configuration like so:
 
 ```toml
 [dependencies]
-xor-cipher = "3.0.0"
+xor-cipher = "4.0.0"
 ```
 
 Alternatively, you can add it directly from the source:

--- a/changelogging.toml
+++ b/changelogging.toml
@@ -1,6 +1,6 @@
 [context]
 name = "xor-cipher"
-version = "3.0.0"
+version = "4.0.0"
 url = "https://github.com/xor-cipher/xor-cipher-crate"
 
 [formats]

--- a/changes/3.change.md
+++ b/changes/3.change.md
@@ -1,0 +1,2 @@
+`xor_slice` and `cyclic_xor_slice` were removed in favor of more general functions,
+`xor` and `cyclic_xor` correspondingly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,12 @@
 ///
 /// This function is its own inverse.
 #[inline]
-pub fn xor_slice(data: &mut [u8], key: u8) {
-    data.iter_mut().for_each(|byte| *byte ^= key);
+pub fn xor<D: AsMut<[u8]>>(mut data: D, key: u8) {
+    fn xor_inner(data: &mut [u8], key: u8) {
+        data.iter_mut().for_each(|byte| *byte ^= key);
+    }
+
+    xor_inner(data.as_mut(), key);
 }
 
 /// Applies XOR operation (`byte ^ key_byte`) for each `byte` in `data`
@@ -17,20 +21,12 @@ pub fn xor_slice(data: &mut [u8], key: u8) {
 ///
 /// This function is its own inverse.
 #[inline]
-pub fn cyclic_xor_slice(data: &mut [u8], key: &[u8]) {
-    data.iter_mut()
-        .zip(key.iter().cycle())
-        .for_each(|(byte, key_byte)| *byte ^= key_byte);
-}
-
-/// Similar to [`xor_slice`], except it is generic over `data`.
-#[inline]
-pub fn xor<D: AsMut<[u8]>>(mut data: D, key: u8) {
-    xor_slice(data.as_mut(), key);
-}
-
-/// Similar to [`cyclic_xor_slice`], except it is generic over `data` and `key`.
-#[inline]
 pub fn cyclic_xor<D: AsMut<[u8]>, K: AsRef<[u8]>>(mut data: D, key: K) {
-    cyclic_xor_slice(data.as_mut(), key.as_ref());
+    fn cyclic_xor_inner(data: &mut [u8], key: &[u8]) {
+        data.iter_mut()
+            .zip(key.iter().cycle())
+            .for_each(|(byte, key_byte)| *byte ^= key_byte);
+    }
+
+    cyclic_xor_inner(data.as_mut(), key.as_ref());
 }


### PR DESCRIPTION
This PR removes `xor_slice` and `cyclic_xor_slice`; instead one should use corresponding generic functions.